### PR TITLE
Fixed make target name misspell for windows.

### DIFF
--- a/docs/hackers/building.rst
+++ b/docs/hackers/building.rst
@@ -99,7 +99,7 @@ Open Visual Studio 2019 Command Prompt:
 
 .. code::
 
-	make tools-linux-release64
+	make tools-windows-release64
 
 To build tools, open MSYS2 MSYS:
 


### PR DESCRIPTION
I just checked it locally and got success :)
```
8>Done building project "crown.vcxproj".
========== Build: 8 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========
```