### PR TITLE
Add a prompt in toolchain.lua for the user to run vcvarsall.bat

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -108,10 +108,14 @@ function toolchain(build_dir, lib_dir)
 			print("Action not valid in current OS.")
 		end
 
-		local windowsPlatform = string.gsub(os.getenv("WindowsSDKVersion") or "8.1", "\\", "")
+		local winKitVer = os.getenv("WindowsSDKVersion")
+		if not winKitVer then
+			print("Run vcvarsall.bat as part of your Visual Studio installation to set the environment variable 'WindowsSDKVersion'.")
+		end
+		winKitVer = string.gsub(winKitVer, "\\", "")
 		local action = premake.action.current()
-		action.vstudio.windowsTargetPlatformVersion    = windowsPlatform
-		action.vstudio.windowsTargetPlatformMinVersion = windowsPlatform
+		action.vstudio.windowsTargetPlatformVersion    = winKitVer
+		action.vstudio.windowsTargetPlatformMinVersion = winKitVer
 
 		location(build_dir .. "projects/" .. _ACTION)
 	end

--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -111,6 +111,7 @@ function toolchain(build_dir, lib_dir)
 		local winKitVer = os.getenv("WindowsSDKVersion")
 		if not winKitVer then
 			print("Run vcvarsall.bat as part of your Visual Studio installation to set the environment variable 'WindowsSDKVersion'.")
+			os.exit(1)
 		end
 		winKitVer = string.gsub(winKitVer, "\\", "")
 		local action = premake.action.current()


### PR DESCRIPTION
 Add a prompt in toolchain.lua for the user to run vcvarsall.bat if their WindowsSDKVersion env var is not set. Don't make 8.1 the default value.

We could do this properly by inspecting registry values but from what I remember this is incredibly fiddly to get right across the different versions, so might be easiest to rely on vcvarsall.bat for now