### PR TITLE
device: do not try to reload unloaded resources

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Changelog
 
 * Lua: fixed max temporaries check failing to trigger in some circumnstances.
 * Fixed a crash when moving many objects simultaneusly.
+* Fixed a crash when reloading unloaded or unsupported resources.
 
 0.54.0 --- 13 Jan 2025
 ----------------------

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -875,14 +875,19 @@ void Device::refresh(const char *json)
 
 		StringId64 resource_type(type);
 		StringId64 resource_name(resource.c_str(), len);
+		bool is_type_reloadable = resource_type == RESOURCE_TYPE_SCRIPT
+			|| resource_type == RESOURCE_TYPE_TEXTURE
+			;
 
-		const void *old_resource = _resource_manager->get(resource_type, resource_name);
-		const void *new_resource = _resource_manager->reload(resource_type, resource_name);
+		if (is_type_reloadable && _resource_manager->can_get(resource_type, resource_name)) {
+			const void *old_resource = _resource_manager->get(resource_type, resource_name);
+			const void *new_resource = _resource_manager->reload(resource_type, resource_name);
 
-		if (resource_type == RESOURCE_TYPE_SCRIPT) {
-			refresh_lua = true;
-		} else if (resource_type == RESOURCE_TYPE_TEXTURE) {
-			_material_manager->reload_textures((TextureResource *)old_resource, (TextureResource *)new_resource);
+			if (resource_type == RESOURCE_TYPE_SCRIPT) {
+				refresh_lua = true;
+			} else if (resource_type == RESOURCE_TYPE_TEXTURE) {
+				_material_manager->reload_textures((TextureResource *)old_resource, (TextureResource *)new_resource);
+			}
 		}
 	}
 


### PR DESCRIPTION
Also, skip reloading unsupported resources.

Fixes: #246