### PR TITLE
tools: enable can_focus for _text_view in console_view

### DIFF
--- a/tools/widgets/console_view.vala
+++ b/tools/widgets/console_view.vala
@@ -136,7 +136,7 @@ public class ConsoleView : Gtk.Box
 
 		_text_view = new Gtk.TextView();
 		_text_view.editable = false;
-		_text_view.can_focus = false;
+		_text_view.can_focus = true;
 
 		// Create tags for color-formatted text.
 		Gtk.TextBuffer tb = _text_view.buffer;


### PR DESCRIPTION
Can copy text from editor console using ctrl + c