### PR TITLE
device: html5: avoid GL_INVALID_OPERATION with untextured meshes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Runtime**
 
+* HTML5: fixed GL_INVALID_OPERATION (or missing geometry) when rendering untextured meshes.
 * Data Compiler: fixed shaders not including code in some circumnstances.
 
 0.55.0 --- 03 Apr 2025

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -892,6 +892,10 @@ void Device::render(World &world, UnitId camera_unit)
 	bgfx::touch(VIEW_GRAPH);
 	bgfx::touch(VIEW_BLIT);
 
+#if CROWN_PLATFORM_EMSCRIPTEN
+	bgfx::setTexture(0, _pipeline->_html5_default_sampler, _pipeline->_html5_default_texture);
+#endif
+
 	world.render(view);
 }
 

--- a/src/device/pipeline.cpp
+++ b/src/device/pipeline.cpp
@@ -133,11 +133,21 @@ void Pipeline::create(uint16_t width, uint16_t height)
 
 	_outline_color_uniform = bgfx::createUniform("u_outline_color", bgfx::UniformType::Vec4);
 
+#if CROWN_PLATFORM_EMSCRIPTEN
+	_html5_default_sampler = bgfx::createUniform("s_webgl_hack", bgfx::UniformType::Sampler);
+	_html5_default_texture = bgfx::createTexture2D(1, 1, false, 1, bgfx::TextureFormat::R8);
+#endif
+
 	PosTexCoord0Vertex::init();
 }
 
 void Pipeline::destroy()
 {
+#if CROWN_PLATFORM_EMSCRIPTEN
+	bgfx::destroy(_html5_default_sampler);
+	bgfx::destroy(_html5_default_texture);
+#endif
+
 	bgfx::destroy(_outline_color_uniform);
 
 	bgfx::destroy(_selection_depth_texture_sampler);

--- a/src/device/pipeline.h
+++ b/src/device/pipeline.h
@@ -52,6 +52,12 @@ struct Pipeline
 	bgfx::UniformHandle _selection_depth_texture_sampler;
 	bgfx::UniformHandle _outline_color_uniform;
 
+	// Default sampler/texture to keep WebGL renderer running
+	// when a shader references a texture (even if unused) but
+	// none are set via setTexture().
+	bgfx::UniformHandle _html5_default_sampler;
+	bgfx::TextureHandle _html5_default_texture;
+
 	// Default shaders.
 	ShaderData _blit_shader;
 	ShaderData _gui_shader;


### PR DESCRIPTION
By setting a default texture before world rendering.

Fixes: #348