### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/3rdparty/lua/src/ldo.c
+++ b/3rdparty/lua/src/ldo.c
@@ -495,8 +495,7 @@ static void f_parser (lua_State *L, void *ud) {
   struct SParser *p = cast(struct SParser *, ud);
   int c = luaZ_lookahead(p->z);
   luaC_checkGC(L);
-  tf = ((c == LUA_SIGNATURE[0]) ? luaU_undump : luaY_parser)(L, p->z,
-                                                             &p->buff, p->name);
+  tf = (luaY_parser)(L, p->z, &p->buff, p->name);
   cl = luaF_newLclosure(L, tf->nups, hvalue(gt(L)));
   cl->l.p = tf;
   for (i = 0; i < tf->nups; i++)  /* initialize eventual upvalues */


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a clone function f_parser() in `3rdparty/lua/src/ldo.c` sourced from [antirez/redis](https://github.com/antirez/redis). This issue, originally reported in [CVE-2015-4335](https://nvd.nist.gov/vuln/detail/CVE-2015-4335), was resolved in the repository via this commit https://github.com/antirez/redis/commit/fdf9d455098f54f7666c702ae464e6ea21e25411.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!