### PR TITLE
tools: drop Gtk.Label.track_visited_links

### DIFF
--- a/tools/level_editor/deploy_dialog.vala
+++ b/tools/level_editor/deploy_dialog.vala
@@ -65,7 +65,7 @@ public class DeployerPage : Gtk.Stack
 		p1l.valign = Gtk.Align.CENTER;
 
 		var p2l = new Gtk.Label(null);
-		p2l.track_visited_links = false;
+		p2l.get_style_context().add_class("colorfast-link");
 		p2l.set_markup(p2);
 		p2l.valign = Gtk.Align.CENTER;
 		p2l.activate_link.connect(() => {

--- a/tools/level_editor/level_editor.vala
+++ b/tools/level_editor/level_editor.vala
@@ -870,7 +870,7 @@ public class LevelEditorApplication : Gtk.Application
 		_editor_stack_disconnected_label = new Gtk.Label("Disconnected.");
 		_editor_stack.add(_editor_stack_disconnected_label);
 		_editor_stack_oops_label = new Gtk.Label(null);
-		_editor_stack_oops_label.track_visited_links = false;
+		_editor_stack_oops_label.get_style_context().add_class("colorfast-link");
 		_editor_stack_oops_label.set_markup("Something went wrong.\rTry to <a href=\"restart\">restart this view</a>.");
 		_editor_stack_oops_label.activate_link.connect(() => {
 				activate_action("restart-editor-view", null);
@@ -887,7 +887,7 @@ public class LevelEditorApplication : Gtk.Application
 		_resource_preview_disconnected_label = new Gtk.Label("Disconnected");
 		_resource_preview_stack.add(_resource_preview_disconnected_label);
 		_resource_preview_oops_label = new Gtk.Label(null);
-		_resource_preview_oops_label.track_visited_links = false;
+		_resource_preview_oops_label.get_style_context().add_class("colorfast-link");
 		_resource_preview_oops_label.set_markup("Something went wrong.\rTry to <a href=\"restart\">restart this view</a>.");
 		_resource_preview_oops_label.activate_link.connect(() => {
 				restart_resource_preview.begin((obj, res) => {
@@ -1490,7 +1490,7 @@ public class LevelEditorApplication : Gtk.Application
 	Gtk.Label compiler_crashed_label()
 	{
 		Gtk.Label label = new Gtk.Label(null);
-		label.track_visited_links = false;
+		label.get_style_context().add_class("colorfast-link");
 		label.set_markup("Data Compiler disconnected.\rTry to <a href=\"restart\">restart the compiler</a> to continue.");
 		label.activate_link.connect(() => {
 				restart_backend.begin(_project.source_dir(), _level._name != null ? _level._name : "");
@@ -1503,7 +1503,7 @@ public class LevelEditorApplication : Gtk.Application
 	Gtk.Label compiler_failed_compilation_label()
 	{
 		Gtk.Label label = new Gtk.Label(null);
-		label.track_visited_links = false;
+		label.get_style_context().add_class("colorfast-link");
 		label.set_markup("Data compilation failed.\rFix errors and <a href=\"restart\">restart the compiler</a> to continue.");
 		label.activate_link.connect(() => {
 				restart_backend.begin(_project.source_dir(), _level._name != null ? _level._name : "");

--- a/tools/level_editor/resources/ui/style.css
+++ b/tools/level_editor/resources/ui/style.css
@@ -82,6 +82,6 @@ button.compact {
 	padding: 0px 2px 0px 2px;
 }
 
-.version-label link {
+.colorfast-link link {
 	color: @theme_fg_color;
 }

--- a/tools/level_editor/statusbar.vala
+++ b/tools/level_editor/statusbar.vala
@@ -36,7 +36,7 @@ public class Statusbar : Gtk.Box
 				GLib.Application.get_default().activate_action("donate", null);
 			});
 		_version = new Gtk.Label(null);
-		_version.track_visited_links = false;
+		_version.get_style_context().add_class("colorfast-link");
 		_version.set_markup("<a href=\"\">" + CROWN_VERSION + "</a>");
 		_version.get_style_context().add_class("version-label");
 		_version.can_focus = false;


### PR DESCRIPTION
It has been removed in GTK4.
Replace with colorfast-link CSS class.

Part-of: #383