### PR TITLE
tools: always use margin_{bottom,end,start,top}

### DIFF
--- a/tools/level_editor/level_editor.vala
+++ b/tools/level_editor/level_editor.vala
@@ -913,7 +913,12 @@ public class LevelEditorApplication : Gtk.Application
 
 		// Game run/stop button.
 		_game_run_stop_image = new Gtk.Image.from_icon_name("game-run", Gtk.IconSize.MENU);
-		_game_run_stop_image.margin = 8;
+		_game_run_stop_image.margin_bottom
+			= _game_run_stop_image.margin_end
+			= _game_run_stop_image.margin_start
+			= _game_run_stop_image.margin_top
+			= 8
+			;
 		_game_run = new Gtk.Button();
 		_game_run.add(_game_run_stop_image);
 		_game_run.get_style_context().add_class("suggested-action");

--- a/tools/level_editor/properties_view.vala
+++ b/tools/level_editor/properties_view.vala
@@ -759,7 +759,12 @@ public class PropertiesView : Gtk.Stack
 
 		// Widgets
 		_object_view = new PropertyGridSet();
-		_object_view.margin = 6;
+		_object_view.margin_bottom
+			= _object_view.margin_end
+			= _object_view.margin_start
+			= _object_view.margin_top
+			= 6
+			;
 
 		// Unit
 		register_object_type("Unit",                    "name",                              0, new UnitView(_db, store));

--- a/tools/level_editor/property_grid.vala
+++ b/tools/level_editor/property_grid.vala
@@ -308,7 +308,12 @@ public class PropertyGridSet : Gtk.Box
 	public PropertyGridSet()
 	{
 		Object(orientation: Gtk.Orientation.VERTICAL, spacing: 0);
-		this.margin = 12;
+		this.margin_bottom
+			= this.margin_end
+			= this.margin_start
+			= this.margin_top
+			= 12
+			;
 	}
 
 	public Expander add_property_grid(PropertyGrid cv, string label)

--- a/tools/level_editor/toolbar.vala
+++ b/tools/level_editor/toolbar.vala
@@ -27,7 +27,7 @@ public class Toolbar : Gtk.Box
 		this.pack_start(make_toggle_button("app.tool", new GLib.Variant.int32(ToolType.MOVE), "tool-move"));
 		this.pack_start(make_toggle_button("app.tool", new GLib.Variant.int32(ToolType.ROTATE), "tool-rotate"));
 		var last = make_toggle_button("app.tool", new GLib.Variant.int32(ToolType.SCALE), "tool-scale");
-		last.margin_bottom = last.margin + 8;
+		last.margin_bottom = last.margin_bottom + 8;
 		this.pack_start(last);
 	}
 
@@ -35,7 +35,7 @@ public class Toolbar : Gtk.Box
 	{
 		this.pack_start(make_toggle_button("app.snap", new GLib.Variant.int32(SnapMode.RELATIVE), "reference-local"));
 		var last = make_toggle_button("app.snap", new GLib.Variant.int32(SnapMode.ABSOLUTE), "reference-world");
-		last.margin_bottom = last.margin + 8;
+		last.margin_bottom = last.margin_bottom + 8;
 		this.pack_start(last);
 	}
 
@@ -43,14 +43,14 @@ public class Toolbar : Gtk.Box
 	{
 		this.pack_start(make_toggle_button("app.reference-system", new GLib.Variant.int32(ReferenceSystem.LOCAL), "axis-local"));
 		var last = make_toggle_button("app.reference-system", new GLib.Variant.int32(ReferenceSystem.WORLD), "axis-world");
-		last.margin_bottom = last.margin + 8;
+		last.margin_bottom = last.margin_bottom + 8;
 		this.pack_start(last);
 	}
 
 	private void add_snap_to_grid_buttons()
 	{
 		var last = make_toggle_button("app.snap-to-grid", null, "snap-to-grid");
-		last.margin_bottom = last.margin + 8;
+		last.margin_bottom = last.margin_bottom + 8;
 		this.pack_start(last);
 	}
 
@@ -69,7 +69,12 @@ public class Toolbar : Gtk.Box
 		btn.get_style_context().add_class("image-button");
 
 		var img = new Gtk.Image.from_icon_name(icon_name, icon_size);
-		img.margin = 8;
+		img.margin_bottom
+			= img.margin_end
+			= img.margin_start
+			= img.margin_top
+			= 8
+			;
 		btn.add(img);
 
 		return btn;


### PR DESCRIPTION
GTK4 removed 'margin' property.

Part-of: #383