### PR TITLE
tools: use equivalent vhomogeneous property

### DIFF
--- a/tools/resource/sprite_resource.vala
+++ b/tools/resource/sprite_resource.vala
@@ -360,7 +360,7 @@ public class SpriteImportDialog : Gtk.Window
 		// Collider.
 		shape = new Gtk.Stack();
 		shape.sensitive = false;
-		shape.homogeneous = false;
+		shape.vhomogeneous = false;
 		shape.notify["visible-child"].connect(() => {
 				calc_collider_shape();
 				_preview.queue_draw();


### PR DESCRIPTION
'homogeneous' has been removed in GTK4.

Part-of: #383