### PR TITLE
device: windows: disable MSAA depth sampling

### DIFF
--- a/samples/core/shaders/editor.shader
+++ b/samples/core/shaders/editor.shader
@@ -76,7 +76,7 @@ bgfx_shaders = {
 		#if BX_PLATFORM_LINUX || BX_PLATFORM_WINDOWS
 			USAMPLER2D(s_selection_map, 0);
 			SAMPLER2D(s_selection_depth_map, 1);
-		#if defined(MSAA_DEPTH)
+		#if defined(MSAA_DEPTH) && !defined(BX_PLATFORM_WINDOWS)
 			SAMPLER2DMS(s_depth_map, 2);
 			uniform vec4 u_outline_msaa_samples;
 		#else
@@ -129,7 +129,7 @@ bgfx_shaders = {
 
 				// Dim alpha if selected object is behind another object.
 				ivec2 coord = ivec2(v_texcoord0 * tex_size);
-			#if defined(MSAA_DEPTH)
+			#if defined(MSAA_DEPTH) && !defined(BX_PLATFORM_WINDOWS)
 				float scene_depth = 0.0;
 				for (int ii = 0; ii < 16; ++ii)
 				{

--- a/src/device/pipeline.cpp
+++ b/src/device/pipeline.cpp
@@ -405,7 +405,7 @@ void Pipeline::reset(u16 width, u16 height)
 	u64 color_texture_flags = BGFX_SAMPLER_U_CLAMP | BGFX_SAMPLER_V_CLAMP;
 	if ((_render_settings.flags & RenderSettingsFlags::MSAA) != 0) {
 		u64 msaa_flags = u64(1 + _render_settings.msaa_quality) << BGFX_TEXTURE_RT_MSAA_SHIFT;
-#if CROWN_PLATFORM_LINUX || CROWN_PLATFORM_WINDOWS
+#if CROWN_PLATFORM_LINUX /* || CROWN_PLATFORM_WINDOWS */
 		depth_texture_flags |= msaa_flags | BGFX_TEXTURE_MSAA_SAMPLE;
 #else
 		depth_texture_flags |= msaa_flags | BGFX_TEXTURE_RT_WRITE_ONLY;


### PR DESCRIPTION
Follow-up to 2a7b71b5e.

Crash only happens on debug Linux. This just makes outlines look bad on Windows when MSAA is enabled for the editor viewport, which is not by default and probably nobody enables anyway.