### PR TITLE
tools: reset blocked state whenever handler changes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,7 @@ Changelog
 * Tools: fixed Project Browser favorites not updating file metadata after resource changes.
 * Tools: fixed Project Browser not restoring favorites metadata when the project is loaded.
 * Tools: fixed labels not showing for some widgets in the Projects and New Project panels.
+* Tools: fixed a warning in the console when interacting with object trees in some cases.
 * Runtime: fixed keyframed physics actors being created with non-zero mass, which made material restitution behave incorrectly.
 * Runtime: fixed ``PhysicsWorld.actor_set_kinematic()`` not updating mass/inertia.
 * Runtime: fixed ``PhysicsWorld.actor_set_kinematic()`` not restoring body deactivation when switching actors back from kinematic.

--- a/tools/level_editor/level_tree_view.vala
+++ b/tools/level_editor/level_tree_view.vala
@@ -274,6 +274,7 @@ public class LevelTreeView : Gtk.Box
 		_tree_selection = _tree_view.get_selection();
 		_tree_selection.set_mode(Gtk.SelectionMode.MULTIPLE);
 		_selection_changed_id = _tree_selection.changed.connect(on_tree_selection_changed);
+		_selection_changed_blocked = false;
 
 		_scrolled_window = new Gtk.ScrolledWindow(null, null);
 		_scrolled_window.add(_tree_view);
@@ -627,6 +628,7 @@ public class LevelTreeView : Gtk.Box
 			});
 
 		_selection_changed_id = _tree_selection.changed.connect(on_tree_selection_changed);
+		_selection_changed_blocked = false;
 	}
 
 	public void on_objects_changed(Guid?[] object_ids, uint32 flags)
@@ -861,6 +863,7 @@ public class LevelTreeView : Gtk.Box
 		}
 
 		_selection_changed_id = _tree_selection.changed.connect(on_tree_selection_changed);
+		_selection_changed_blocked = false;
 		on_tree_selection_changed();
 
 		return i;
@@ -882,6 +885,7 @@ public class LevelTreeView : Gtk.Box
 		}
 
 		_selection_changed_id = _tree_selection.changed.connect(on_tree_selection_changed);
+		_selection_changed_blocked = false;
 		on_tree_selection_changed();
 
 		return i;
@@ -1057,6 +1061,7 @@ public class LevelTreeView : Gtk.Box
 		_tree_store.foreach(save_tree_state);
 		filter(_needle);
 		_selection_changed_id = _tree_selection.changed.connect(on_tree_selection_changed);
+		_selection_changed_blocked = false;
 	}
 
 	public void on_search_changed()
@@ -1064,6 +1069,7 @@ public class LevelTreeView : Gtk.Box
 		_tree_selection.changed.disconnect(on_tree_selection_changed);
 		filter(_needle);
 		_selection_changed_id = _tree_selection.changed.connect(on_tree_selection_changed);
+		_selection_changed_blocked = false;
 	}
 
 	public void on_search_stopped()
@@ -1084,6 +1090,7 @@ public class LevelTreeView : Gtk.Box
 		_tree_view.get_selection().unselect_all();
 		_tree_store.foreach(restore_tree_state);
 		_selection_changed_id = _tree_selection.changed.connect(on_tree_selection_changed);
+		_selection_changed_blocked = false;
 
 		// If the selection changed while searching, restore it as well.
 		for (int i = 0; i < selected_refs.length; ++i) {

--- a/tools/widgets/object_tree.vala
+++ b/tools/widgets/object_tree.vala
@@ -164,6 +164,7 @@ public class ObjectTree : Gtk.Box
 		_tree_selection = _tree_view.get_selection();
 		_tree_selection.set_mode(Gtk.SelectionMode.SINGLE);
 		_selection_changed_id = _tree_selection.changed.connect(on_tree_selection_changed);
+		_selection_changed_blocked = false;
 
 		_scrolled_window = new Gtk.ScrolledWindow(null, null);
 		_scrolled_window.add(_tree_view);
@@ -614,6 +615,7 @@ public class ObjectTree : Gtk.Box
 			_tree_view.scroll_to_cell(last_selected, null, false, 0.0f, 0.0f);
 
 		_selection_changed_id = _tree_selection.changed.connect(on_tree_selection_changed);
+		_selection_changed_blocked = false;
 	}
 
 	public bool save_tree_state(Gtk.TreeModel model, Gtk.TreePath path, Gtk.TreeIter iter)
@@ -725,6 +727,7 @@ public class ObjectTree : Gtk.Box
 		_tree_store.foreach(save_tree_state);
 		filter(_needle);
 		_selection_changed_id = _tree_selection.changed.connect(on_tree_selection_changed);
+		_selection_changed_blocked = false;
 	}
 
 	public void on_search_changed()
@@ -732,6 +735,7 @@ public class ObjectTree : Gtk.Box
 		_tree_selection.changed.disconnect(on_tree_selection_changed);
 		filter(_needle);
 		_selection_changed_id = _tree_selection.changed.connect(on_tree_selection_changed);
+		_selection_changed_blocked = false;
 	}
 
 	public void on_search_stopped()
@@ -752,6 +756,7 @@ public class ObjectTree : Gtk.Box
 		_tree_view.get_selection().unselect_all();
 		_tree_store.foreach(restore_tree_state);
 		_selection_changed_id = _tree_selection.changed.connect(on_tree_selection_changed);
+		_selection_changed_blocked = false;
 
 		// If the selection changed while searching, restore it as well.
 		for (int i = 0; i < selected_refs.length; ++i) {


### PR DESCRIPTION
The selection_changed handler could change between block()/unblock() pairs, causing the unblock() to emit a warning on mismatches.