### PR TITLE
tools: widgets: input_color3.vala: fix undo-redo

### DIFF
--- a/tools/level_editor/property_grid.vala
+++ b/tools/level_editor/property_grid.vala
@@ -599,16 +599,16 @@ public class PropertyGrid : Gtk.Grid
 		read_dynamic_properties_ranges_except({ def });
 
 		UndoRedo? ur = null;
-		if (undo_redo == 0)
+		if (undo_redo == 0 || undo_redo == -1)
 			ur = _db.disable_undo();
 
 		changed = restore_dynamic_properties_values_except(dynamic_properties, dynamic_values, { def }) || changed;
 		changed = write_property_if_changed(def, p.union_value()) || changed;
 
-		if (changed)
+		if (changed && undo_redo != -1)
 			_db.add_restore_point(ActionType.CHANGE_OBJECTS, new Guid?[] { _id });
 
-		if (undo_redo == 0)
+		if (undo_redo == 0 || undo_redo == -1)
 			_db.restore_undo(ur);
 
 		if (_database_editor != null && _selection_anchor_id != GUID_ZERO)

--- a/tools/widgets/input_color3.vala
+++ b/tools/widgets/input_color3.vala
@@ -220,6 +220,7 @@ static Cairo.MeshPattern create_circle_mesh(double cx, double cy, double r, doub
 public class InputColor3 : InputField
 {
 	public bool _dragging;
+	public bool _silent;
 	public Vector3 _drag_start_rgb;
 	public int _hs_palette_radius;
 	public double _hs_lens_radius_scale;
@@ -519,7 +520,7 @@ public class InputColor3 : InputField
 
 		_hs_palette.queue_draw();
 
-		value_changed(this, (int)!_dragging);
+		value_changed(this, _silent ? -1 : (int)!_dragging);
 	}
 
 	public void on_hsv_value_changed()
@@ -546,7 +547,7 @@ public class InputColor3 : InputField
 
 		_hs_palette.queue_draw();
 
-		value_changed(this, (int)!_dragging);
+		value_changed(this, _silent ? -1 : (int)!_dragging);
 	}
 
 	public void disconnect_rgb()
@@ -645,7 +646,9 @@ public class InputColor3 : InputField
 		double v = 1.0;
 
 		Vector3 current_value = this.value;
+		_silent = true;
 		this.value = _drag_start_rgb;
+		_silent = false;
 		_dragging = false;
 
 		disconnect_rgb();
@@ -721,7 +724,9 @@ public class InputColor3 : InputField
 		double v = 1.0;
 
 		Vector3 current_value = this.value;
+		_silent = true;
 		this.value = _drag_start_rgb;
+		_silent = false;
 		_dragging = false;
 
 		disconnect_rgb();


### PR DESCRIPTION
Add property_grid.vala.undo_redo == -1 to skip restore-point callback