### PR TITLE
Tools: Windows: fix EditorView RMB

### DIFF
--- a/tools/widgets/drag/infinite_drag_controller.vala
+++ b/tools/widgets/drag/infinite_drag_controller.vala
@@ -4,7 +4,7 @@
  */
 
 [CCode (cname = "crown_infinite_drag_sampler_start")]
-extern void* infinite_drag_sampler_start(Gdk.Display display, Gdk.Window window, Gdk.Device device, int trigger_button, int cancel_button);
+extern void* infinite_drag_sampler_start(Gdk.Display display, Gdk.Window window, Gdk.Device device, int trigger_button, int cancel_button, bool preserve_legacy_events);
 [CCode (cname = "crown_infinite_drag_sampler_drain")]
 extern void infinite_drag_sampler_drain(void* sampler, out double delta_x, out double delta_y, out double wheel_dx, out double wheel_dy, out int samples);
 [CCode (cname = "crown_infinite_drag_sampler_released")]
@@ -33,6 +33,8 @@ public class InfiniteDragController : GLib.Object
 	public int trigger_button = Gdk.BUTTON_PRIMARY;
 	/// Pointer button that cancels the drag instead of committing it; 0 disables it.
 	public int cancel_button = Gdk.BUTTON_SECONDARY;
+	/// Whether the native sampler should preserve regular GDK pointer events.
+	public bool preserve_legacy_events = false;
 
 	public signal void drag_started();
 	public signal void drag_delta(double dx, double dy, double total_dx, double total_dy);
@@ -77,7 +79,8 @@ public class InfiniteDragController : GLib.Object
 				get_pointer();
 
 			_sampler = infinite_drag_sampler_start(_widget.get_display(), _widget.
-				get_window(), pointer, trigger_button, cancel_button);
+				get_window(), pointer, trigger_button, cancel_button,
+				preserve_legacy_events);
 		}
 		if (_sampler == null) {
 			loge("InfiniteDragController: sampler failed to start");

--- a/tools/widgets/drag/infinite_drag_sampler.c
+++ b/tools/widgets/drag/infinite_drag_sampler.c
@@ -41,6 +41,7 @@ typedef struct CrownInfiniteDragSampler
 	gint anchor_y;
 	gint trigger_button;
 	gint cancel_button;
+	gboolean preserve_legacy_events;
 	gdouble delta_x;
 	gdouble delta_y;
 	gdouble wheel_dx;
@@ -335,13 +336,15 @@ static const wchar_t WINDOWS_RAW_INPUT_CLASS_NAME[] = L"CrownInfiniteDragRawInpu
 
 /* Event-driven only: do not replace with cursor-position polling or repeated SetCursorPos calls. */
 
-static gboolean register_windows_raw_input(HWND target)
+static gboolean register_windows_raw_input(HWND target, gboolean preserve_legacy_events)
 {
 	RAWINPUTDEVICE mouse =
 	{
 		.usUsagePage = 0x01,
 		.usUsage = 0x02,
-		.dwFlags = target != NULL ? RIDEV_INPUTSINK | RIDEV_NOLEGACY : RIDEV_REMOVE,
+		.dwFlags = target != NULL
+			? RIDEV_INPUTSINK | (preserve_legacy_events ? 0 : RIDEV_NOLEGACY)
+			: RIDEV_REMOVE,
 		.hwndTarget = target,
 	};
 	if (RegisterRawInputDevices(&mouse, 1, sizeof(mouse)))
@@ -498,7 +501,7 @@ static gpointer sample_pointer_windows(gpointer data)
 	if (window == NULL)
 		goto setup_failed;
 
-	if (!register_windows_raw_input(window))
+	if (!register_windows_raw_input(window, sampler->preserve_legacy_events))
 		goto setup_failed;
 	registered = TRUE;
 
@@ -536,13 +539,13 @@ static gpointer sample_pointer_windows(gpointer data)
 	SetCursorPos(sampler->anchor_x, sampler->anchor_y);
 	ClipCursor(NULL);
 
-	register_windows_raw_input(NULL);
+	register_windows_raw_input(NULL, FALSE);
 	DestroyWindow(window);
 	return NULL;
 
 setup_failed:
 	if (registered)
-		register_windows_raw_input(NULL);
+		register_windows_raw_input(NULL, FALSE);
 	if (window != NULL)
 		DestroyWindow(window);
 	g_atomic_int_set(&sampler->running, FALSE);
@@ -561,7 +564,7 @@ static gpointer sample_pointer(gpointer data)
 	return NULL;
 }
 
-void *crown_infinite_drag_sampler_start(GdkDisplay *display, GdkWindow *window, GdkDevice *device, gint trigger_button, gint cancel_button)
+void *crown_infinite_drag_sampler_start(GdkDisplay *display, GdkWindow *window, GdkDevice *device, gint trigger_button, gint cancel_button, gboolean preserve_legacy_events)
 {
 	CrownInfiniteDragSampler *sampler = g_new0(CrownInfiniteDragSampler, 1);
 	g_mutex_init(&sampler->mutex);
@@ -571,6 +574,7 @@ void *crown_infinite_drag_sampler_start(GdkDisplay *display, GdkWindow *window, 
 	g_atomic_int_set(&sampler->running, TRUE);
 	sampler->trigger_button = trigger_button;
 	sampler->cancel_button = cancel_button;
+	sampler->preserve_legacy_events = preserve_legacy_events;
 	#if defined(__linux__)
 	sampler->x11_wake_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
 	if (sampler->x11_wake_fd < 0) {

--- a/tools/widgets/editor_view.vala
+++ b/tools/widgets/editor_view.vala
@@ -177,6 +177,7 @@ public class EditorView : Gtk.EventBox
 			_flythrough_drag.activation_margin = 0.0;
 			_flythrough_drag.trigger_button = Gdk.BUTTON_SECONDARY; // must match the button start()
 			_flythrough_drag.cancel_button = 0; // rmb itself drives flythrought; no separate abort button
+			_flythrough_drag.preserve_legacy_events = true; // let GTK observe the matching rmb release
 			_flythrough_drag.drag_delta.connect(on_flythrough_drag_delta);
 			_flythrough_drag.drag_scroll.connect(on_scroll);
 			_flythrough_drag.drag_finished.connect(on_flythrough_drag_finished);


### PR DESCRIPTION
RIDEV_NOLEGACY suppressed GTK's matching right-button release, leaving its implicit pointer grab active.